### PR TITLE
DM-48491: Modify simbad query code so it works with astroquery 0.4.8 and 0.4.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,13 +12,12 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.11"
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
+          channels: conda-forge,defaults
           show-channel-urls: true
           activate-environment: test
 
@@ -26,11 +25,11 @@ jobs:
         # Might be quicker to install rubin-env plus any necessary additions.
         shell: bash -l {0}
         run: |
-          mamba install -y  "numpy>1.15" scipy "matplotlib>3.1" pandas llvmlite numba "astropy>=3.2" "photutils>=1.7" astroquery coloredlogs scikit-image>=0.20 h5py emcee tqdm mpi4py schwimmbad "iminuit>=2" "coverage>=3.6" configparser coveralls deprecated pyyaml pytest pytest-cov rubin-libradtran "getCalspec>=2.0.0"
+          conda install -y  "numpy>1.15" scipy "matplotlib>3.1" pandas llvmlite numba "astropy>=3.2" "photutils>=1.7" astroquery coloredlogs scikit-image>=0.20 h5py emcee tqdm mpi4py schwimmbad "iminuit>=2" "coverage>=3.6" configparser coveralls deprecated pyyaml pytest pytest-cov rubin-libradtran "getCalspec>=2.0.0"
           # python -c "from getCalspec.rebuild import rebuild_tables; rebuild_tables()"
-          pip install lsst.utils
+          pip install lsst-utils
           pip install git+https://github.com/LSSTDESC/getObsAtmo.git@main
-          mamba install astrometry
+          conda install astrometry
 
       - name: Download test data
         shell: bash -l {0}

--- a/spectractor/extractor/targets.py
+++ b/spectractor/extractor/targets.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+import packaging.version
 from astropy.coordinates import SkyCoord, Distance
 import astropy.units as u
 from astropy.time import Time
@@ -13,6 +15,13 @@ from spectractor.extractor.spectroscopy import (Lines, HGAR_LINES, HYDROGEN_LINE
                                                 ISM_LINES, STELLAR_LINES)
 
 from getCalspec import getCalspec
+
+# Astroquery versions change the Simbad API.
+_astroquery_version = packaging.version.parse(importlib.metadata.version("astroquery"))
+if _astroquery_version < packaging.version.parse("0.4.8"):
+    _USE_NEW_SIMBAD = False
+else:
+    _USE_NEW_SIMBAD = True
 
 
 def load_target(label, verbose=False):
@@ -259,8 +268,20 @@ class Star(Target):
         simbadQuerier = SimbadClass()
         patchSimbadURL(simbadQuerier)
 
-        simbadQuerier.add_votable_fields('flux(U)', 'flux(B)', 'flux(V)', 'flux(R)', 'flux(I)', 'flux(J)', 'sptype',
-                                         'parallax', 'pm', 'z_value')
+        if _USE_NEW_SIMBAD:
+            simbadQuerier.add_votable_fields('U', 'B', 'V', 'R', 'I', 'J', 'sp_type',
+                                             'parallax', 'propermotions', 'rvz_redshift')
+            ra_key = "ra"
+            dec_key = "dec"
+            redshift_key = "rvz_redshift"
+        else:
+            simbadQuerier.add_votable_fields(
+                'flux(U)', 'flux(B)', 'flux(V)', 'flux(R)', 'flux(I)', 'flux(J)', 'sptype',
+                'parallax', 'pm', 'z_value'
+            )
+            ra_key = "RA"
+            dec_key = "DEC"
+            redshift_key = "Z_VALUE"
         if not getCalspec.is_calspec(self.label) and getCalspec.is_calspec(self.label.replace(".", " ")):
             self.label = self.label.replace(".", " ")
         astroquery_label = self.label
@@ -272,12 +293,17 @@ class Star(Target):
         if self.simbad_table is not None:
             if self.verbose or True:
                 self.my_logger.info(f'\n\tSimbad:\n{self.simbad_table}')
-            self.radec_position = SkyCoord(self.simbad_table['RA'][0] + ' ' + self.simbad_table['DEC'][0], unit=(u.hourangle, u.deg))
+            if _USE_NEW_SIMBAD:
+                self.radec_position = SkyCoord(self.simbad_table[ra_key][0], self.simbad_table[dec_key][0], unit="deg")
+            else:
+                self.radec_position = SkyCoord(
+                    self.simbad_table[ra_key][0] + ' ' + self.simbad_table[dec_key][0], unit=(u.hourangle, u.deg)
+                )
         else:
             raise RuntimeError(f"Target {self.label} not found in Simbad")
         self.get_radec_position_after_pm(date_obs="J2000")
-        if not np.ma.is_masked(self.simbad_table['Z_VALUE']):
-            self.redshift = float(self.simbad_table['Z_VALUE'])
+        if not np.ma.is_masked(self.simbad_table[redshift_key]):
+            self.redshift = float(self.simbad_table[redshift_key])
         else:
             self.redshift = 0
         self.load_spectra()
@@ -379,13 +405,21 @@ class Star(Target):
 
     def get_radec_position_after_pm(self, date_obs):
         if self.simbad_table is not None:
-            target_pmra = self.simbad_table[0]['PMRA'] * u.mas / u.yr
+            if _USE_NEW_SIMBAD:
+                pmra_key = 'pmra'
+                pmdec_key = 'pmdec'
+                plx_value_key = 'plx_value'
+            else:
+                pmra_key = 'PMRA'
+                pmdec_key = 'PMDEC'
+                plx_value_key = 'PLX_VALUE'
+            target_pmra = self.simbad_table[0][pmra_key] * u.mas / u.yr
             if np.isnan(target_pmra):
                 target_pmra = 0 * u.mas / u.yr
-            target_pmdec = self.simbad_table[0]['PMDEC'] * u.mas / u.yr
+            target_pmdec = self.simbad_table[0][pmdec_key] * u.mas / u.yr
             if np.isnan(target_pmdec):
                 target_pmdec = 0 * u.mas / u.yr
-            target_parallax = self.simbad_table[0]['PLX_VALUE'] * u.mas
+            target_parallax = self.simbad_table[0][plx_value_key] * u.mas
             if target_parallax == 0 * u.mas:
                 target_parallax = 1e-4 * u.mas
             target_coord = SkyCoord(ra=self.radec_position.ra, dec=self.radec_position.dec,


### PR DESCRIPTION
* querying filter fluxes now wants U and not flux(U)
* querying proper motions wants "propermotions" not "pm"
* "z_scale" -> "rvz_redshift" (this is translated with warning)
* "sptype" -> "sp_type" (this is translated with warning)

The types of coordinates are now degrees and not strings. The columns in the response are now all lower case instead of all upper case.