### PR TITLE
Switch from nose to pytest in eups build

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,4 +1,4 @@
 build() {
    default_build
-   nosetests
+   pytest --log-cli-level=INFO tests
 }


### PR DESCRIPTION
nosetests is broken on rubinenv 10